### PR TITLE
add oc kubectl virtctl path

### DIFF
--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -7,6 +7,9 @@ source hack/common.sh
 prefix=${DOCKER_PREFIX:-kubevirt}
 tag=${DOCKER_TAG:-v0.8.0-alpha.1}
 kubeconfig=${KUBECONFIG:-~/.kube/config}
+OC_PATH=$(command -v oc)
+KUBECTL_PATH=$(which kubectl)
+VIRTCTL_PATH=$(which virtctl)
 
-${TESTS_OUT_DIR}/tests.test -kubeconfig=$kubeconfig -tag=$tag -prefix=$prefix ${FUNC_TEST_ARGS}
-${TESTS_OUT_DIR}/cdi.test -kubeconfig=$kubeconfig -tag=$tag -prefix=$prefix ${CDI_TEST_ARGS}
+${TESTS_OUT_DIR}/tests.test -kubeconfig=$kubeconfig -tag=$tag -prefix=$prefix -oc-path=${OC_PATH} -kubectl-path=${KUBECTL_PATH} -virtctl-path=${VIRTCTL_PATH} ${FUNC_TEST_ARGS}
+${TESTS_OUT_DIR}/cdi.test -kubeconfig=$kubeconfig -tag=$tag -prefix=$prefix -oc-path=${OC_PATH} -kubectl-path=${KUBECTL_PATH} -virtctl-path=${VIRTCTL_PATH} ${CDI_TEST_ARGS}


### PR DESCRIPTION
Signed-off-by: Shiyang Wang <shiywang@redhat.com>

if this is not working, we can also adding a lookup binary function like my pr here: https://github.com/kubevirt/kubevirt-ansible/pull/354/files#diff-8337e1399854c6a050cd98f558f9ce68R82